### PR TITLE
Clarify backpropagation option in help

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -149,7 +149,7 @@ void showHelp(const vector<string>& args)
              << "  -k               Number of population winners to keep per generation\n"
              << "  -i               Number of images to train on per generation\n"
              << "  -n               Network file to load/save for backpropagation\n"
-             << "  --backpropagation  Use backpropagation instead of genetic algorithm\n"
+             << "  --backpropagation  Use backpropagation instead of the genetic algorithm\n"
              << "  --standard  use standard for dev and save time\n";
     }
     else if (args[1] == "vectors")


### PR DESCRIPTION
## Summary
- Clarify the `--backpropagation` option in the `train` command help text to show the feature is available.

## Testing
- `g++ -std=c++17 main.cpp hashKey.cpp -o mdnn` *(fails: MNISTImageReader.h missing)*

------
https://chatgpt.com/codex/tasks/task_e_68bca7d9087083339c9145ee9afcc292